### PR TITLE
remove global bvcog config

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
     #     before_action :authenticate_user!
     # end
     before_action :configure_permitted_parameters, if: :devise_controller?
-    before_action :set_global_config
 
     protected
 
@@ -12,12 +11,6 @@ class ApplicationController < ActionController::Base
 
     def configure_permitted_parameters
         devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name])
-    end
-    # Fetch the last bvcog_config from the database
-    # and set this as the global config, so that other
-    # controllers can access it.
-    def set_global_config
-        @bvcog_config = BvcogConfig.last
     end
 
 end

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -209,14 +209,15 @@ class ContractsController < ApplicationController
       next if @contract.contract_documents.find_by(orig_file_name: doc.original_filename)
 
       # Write the file to the filesystem
-      File.open(Rails.root.join(@bvcog_config.contracts_path, official_file_name), 'wb') do |file|
+      bvcog_config = BvcogConfig.last
+      File.open(Rails.root.join(bvcog_config.contracts_path, official_file_name), 'wb') do |file|
         file.write(doc.read)
       end
       # Create a new contract_document
       contract_document = ContractDocument.new(
         orig_file_name: doc.original_filename,
         file_name: official_file_name,
-        full_path: Rails.root.join(@bvcog_config.contracts_path, official_file_name).to_s
+        full_path: Rails.root.join(bvcog_config.contracts_path, official_file_name).to_s
       )
       # Add the contract_document to the contract
       @contract.contract_documents << contract_document

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -46,10 +46,12 @@ class ReportsController < ApplicationController
     # For now default to the first user (id = 1)
     @report.created_by = User.find(1).id
 
+    bvcog_config = BvcogConfig.last
+
     # Here we will generate the file path and PDF file
     # For now, we will just create the path
     @report.file_name = "#{SecureRandom.uuid}.pdf"
-    @report.full_path = Rails.root.join(@bvcog_config.reports_path, @report.file_name).to_s
+    @report.full_path = Rails.root.join(bvcog_config.reports_path, @report.file_name).to_s
 
     contracts = []
     # Collect contracts if needed


### PR DESCRIPTION
Removes the usage of a global `@bvcog_config` object and instead queries it where needed.
This is done to assist Liam in fixing cucumber tests that fail due to not finding this global state.