### PR TITLE
Initial logic for contract duration updates

### DIFF
--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -231,6 +231,7 @@ class ContractsController < ApplicationController
 			key_words
 			starts_at
 			ends_at
+            ends_at_final
 			contract_status
 			entity_id
 			program_id
@@ -249,6 +250,13 @@ class ContractsController < ApplicationController
 			contract_documents_attributes
 			contract_document_type_hidden
 			renewal_count
+            max_renewal_count
+            renewal_duration
+            renewal_duration_units
+            extension_count
+            max_extension_count
+            extension_duration
+            extension_duration_units
 		]
 		params.require(:contract).permit(allowed)
 	end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -8,15 +8,27 @@ class Contract < ApplicationRecord
   validates :point_of_contact_id, presence: true
   validates :vendor_id, presence: true
   validates :starts_at, presence: true
-  validates :ends_at, comparison: { greater_than_or_equal_to: :starts_at }
+  validates :ends_at, comparison: { greater_than_or_equal_to: :starts_at }, if: -> { end_trigger == "limited_term" }
+  validates :ends_at_final, comparison: { greater_than_or_equal_to: :ends_at }, if: -> { end_trigger == "limited_term" }
+
   validates :amount_dollar, numericality: { greater_than_or_equal_to: 0 }
   validates :initial_term_amount, numericality: { greater_than_or_equal_to: 0 }
   validates :contract_type, presence: true, inclusion: { in: ContractType.list }
   validates :contract_status, inclusion: { in: ContractStatus.list }
   validates :amount_duration, inclusion: { in: TimePeriod.list }
   validates :initial_term_duration, inclusion: { in: TimePeriod.list }
+  
   validates :end_trigger, inclusion: { in: EndTrigger.list }
-  validates :renewal_count, numericality: { greater_than_or_equal_to: 0 }
+
+  validates :renewal_count, numericality: { greater_than_or_equal_to: 0, less_that_or_equal_to: :max_renewal_count}, if: -> {end_trigger == "limited_term"}
+  validates :max_renewal_count, numericality: { greater_than_or_equal_to: :renewal_count }, if: -> {end_trigger == "limited_term"}
+  validates :renewal_duration, numericality: { greater_than_or_equal_to: 0 }, if: -> {end_trigger == "limited_term"}
+  validates :renewal_duration_units, inclusion: { in: TimePeriod.list }, if: -> {end_trigger == "limited_term"}
+
+  validates :extension_count, numericality: { greater_than_or_equal_to: 0, less_that_or_equal_to: :max_extension_count}, if: -> {end_trigger == "limited_term"}
+  validates :max_extension_count, numericality: { greater_than_or_equal_to: :extension_count }, if: -> {end_trigger == "limited_term"}
+  validates :extension_duration, numericality: { greater_than_or_equal_to: 0 }, if: -> {end_trigger == "limited_term"}
+  validates :extension_duration_units, inclusion: { in: TimePeriod.list }, if: -> {end_trigger == "limited_term"}
 
   belongs_to :entity, class_name: 'Entity', foreign_key: 'entity_id'
   belongs_to :program, class_name: 'Program', foreign_key: 'program_id'
@@ -37,7 +49,8 @@ class Contract < ApplicationRecord
   end
 
   def expired?
-    ends_at < Date.today
+    #TODO Verify this behavior.
+    ends_at < Date.today or final_ends_at < Date.today
   end
 
   public :send_expiry_reminder

--- a/app/views/contracts/_contract.html.erb
+++ b/app/views/contracts/_contract.html.erb
@@ -28,12 +28,35 @@
                             </tr>
                             <tr>
                                 <td><strong>Initial Term:</strong></td>
-                                <td><%= @contract.initial_term_amount %> <%= @contract.initial_term_duration_humanize %><%= @contract.initial_term_amount > 1 ? "s" : "" %></td>
+                                <td><%= @contract.initial_term_amount %> <%= @contract.initial_term_duration %><%= @contract.initial_term_amount > 1 ? "s" : "" %></td>
                             </tr>
-                            <tr>
-                                <td><strong>Remaining renewals:</strong></td>
-                                <td><%= @contract.renewal_count %></td>
-                            </tr>
+
+                            <% if @contract.renewal_count && contract.end_trigger == "limited_term"%>
+                                <tr>
+                                    <td><strong>Remaining renewals:</strong></td>
+                                    <td><%= @contract.renewal_count %></td>
+                                </tr>
+                            <% end %>
+                            <% if @contract.renewal_count && contract.end_trigger == "limited_term"%>
+                                <tr>
+                                    <td><strong>Renewal Period:</strong></td>
+                                    <td><%= @contract.renewal_duration %> <%= @contract.renewal_duration_units %><%= @contract.renewal_duration > 1 ? "s" : "" %></td></td>
+                                </tr>
+                            <% end %>
+
+                            <% if @contract.extension_count && contract.end_trigger == "limited_term"%>
+                                <tr>
+                                    <td><strong>Remaining extensions:</strong></td>
+                                    <td><%= @contract.extension_count %></td>
+                                </tr>
+                            <% end %>
+                            <% if @contract.renewal_count && contract.end_trigger == "limited_term"%>
+                                <tr>
+                                    <td><strong>Renewal Period:</strong></td>
+                                    <td><%= @contract.extension_duration %> <%= @contract.extension_duration_units %><%= @contract.extension_duration > 1 ? "s" : "" %></td></td>
+                                </tr>
+                            <% end %>
+
                             <tr>
                                 <td><strong>End Trigger:</strong></td>
                                 <td><%= @contract.end_trigger_humanize %></td>
@@ -61,10 +84,18 @@
                                 <td><strong>Start Date:</strong></td>
                                 <td><%= @contract.starts_at.strftime("%B %d, %Y") %></td>
                             </tr>
-                            <tr>
-                                <td><strong>End Date:</strong></td>
-                                <td><%= @contract.ends_at.strftime("%B %d, %Y") %></td>
-                            </tr>
+                            <% if @contract.ends_at && contract.end_trigger == "limited_term"%>
+                                <tr>
+                                    <td><strong>End Date:</strong></td>
+                                    <td><%= @contract.ends_at.strftime("%B %d, %Y") %></td>
+                                </tr>
+                            <% end %>
+                            <% if @contract.ends_at_final && contract.end_trigger == "limited_term"%>
+                                <tr>
+                                    <td><strong>Final End Date:</strong></td>
+                                    <td><%= @contract.ends_at_final.strftime("%B %d, %Y") %></td>
+                                </tr>
+                            <% end %>
                             <tr>
                                 <td><strong>Requires Rebid:</strong></td>
                                 <td>

--- a/app/views/contracts/_form.html.erb
+++ b/app/views/contracts/_form.html.erb
@@ -1,3 +1,11 @@
+<style>
+.bottom-align {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  height: 100%;
+}
+</style>
 <div id="contract-form">
   <div class="card">
     <header class="card-header">
@@ -46,6 +54,44 @@
 
           <script type="text/javascript">
             var vendorOptions = <%= vendor_select_options_json.html_safe %>;
+            function updateForm() {
+              // Get the user input from the text input
+              const userInput = document.getElementById('contract_end_trigger').value;
+              var contract_end_trigger_label = document.getElementById('contract_end_trigger_label');
+              var contract_date_entry_div = document.getElementById('contract_date_entry');
+              var contract_renewal_extension_entry_div = document.getElementById('contract_renewal_extension_entry');
+              var contract_final_end_date_entry_div = document.getElementById('final_end_date_entry');
+              var contract_initial_end_date_entry_div = document.getElementById('initial_end_date_entry');              
+
+              if(userInput === "limited_term" || userInput === "continuous") {
+                contract_end_trigger_label.innerHTML = "Length of contract";
+              }
+              else if (userInput === "upon_completion") {
+                contract_end_trigger_label.innerHTML = "End trigger";
+              }
+              else {
+                contract_end_trigger_label.innerHTML = "End trigger/length of contract"
+              }
+
+              if(userInput === "limited_term") {
+                contract_date_entry_div.style.display = 'block'
+                contract_renewal_extension_entry_div.style.display = 'block'
+                contract_final_end_date_entry_div.style.display = 'block';
+                contract_initial_end_date_entry_div.style.display = 'block';
+              }
+              else if (userInput === "upon_completion" || userInput === "continuous"){
+                contract_date_entry_div.style.display = 'block'
+                contract_renewal_extension_entry_div.style.display = 'none'
+                contract_final_end_date_entry_div.style.display = 'none';
+                contract_initial_end_date_entry_div.style.display = 'none';
+              }
+              else{
+                contract_date_entry_div.style.display = 'none'
+                contract_renewal_extension_entry_div.style.display = 'none'
+              }
+
+              console.log(userInput)
+            }
           </script>
           <!-- A text input field for entering a new vendor name, initially hidden -->
                 <div id="new_vendor_field" class="field is-hidden">
@@ -92,18 +138,32 @@
         </div>
 
         <div class="column is-6">
-          <%# Start Date and End Date %>
-          <div class="columns">
-            <div class="column is-6">
-              <div class="field">
-                <%= form.label :start_date %>
-                <%= form.date_field :starts_at, class: "input" %>
+          <%# End Trigger %>
+          <div class="field">
+            <%= form.label :"End trigger/length of contract", id:"contract_end_trigger_label"%>
+            <%= form.select :end_trigger, EndTrigger.to_a, {:include_blank => true}, class: "input", onclick:"updateForm()", id: "contract_end_trigger" %>
+          </div>
+
+          <div id="contract_date_entry">
+            <%# Start Date & End Date & Final End Date%>
+            <div class="columns">
+              <div class="column is-4">
+                <div class="field">
+                  <%= form.label :start_date %>
+                  <%= form.date_field :starts_at, class: "input" %>
+                </div>
               </div>
-            </div>
-            <div class="column is-6">
-              <div class="field">
-                <%= form.label :end_date %>
-                <%= form.date_field :ends_at, class: "input" %>
+              <div class="column is-4">
+                <div class="field" id="initial_end_date_entry">
+                  <%= form.label :end_date_of_initial_term %>
+                  <%= form.date_field :ends_at, class: "input" %>
+                </div>
+              </div>
+              <div class="column is-4">
+                <div class="field" id="final_end_date_entry">
+                  <%= form.label :ends_at_final, "Final end date"%>
+                  <%= form.date_field :ends_at_final, class: "input" %>
+                </div>
               </div>
             </div>
           </div>
@@ -129,15 +189,9 @@
             </div>
           </div>
 
-          <%# End Trigger %>
-          <div class="field">
-            <%= form.label :end_trigger %>
-            <%= form.select :end_trigger, EndTrigger.to_a, {:include_blank => true}, class: "input" %>
-          </div>
-
-          <%# Initial Term Amount, Initial Term Duration, and Remaining Renewals %>
+          <%# Initial Term Amount, Initial Term Duration%>
           <div class="columns">
-            <div class="column is-4">
+            <div class="column is-6">
               <div class="field">
                 <%= form.label :initial_term_amount %>
                 <p class="control has-icons-left">
@@ -148,16 +202,66 @@
                 </p>
               </div>
             </div>
-            <div class="column is-4">
+            <div class="column is-6">
               <div class="field">
                 <%= form.label :initial_term_duration %>
                 <%= form.select :initial_term_duration, TimePeriod.to_a, {:include_blank => true}, class: "input " %>
               </div>
             </div>
-            <div class="column is-4">
-              <div class="field">
-                <%= form.label :renewal_count, "Remaining renewals" %>
-                <%= form.number_field :renewal_count, class: "input" %>
+          </div>
+
+          <div id="contract_renewal_extension_entry">
+            <div class="columns">
+              <div class="column is-3">
+                <div class="field bottom-align">
+                  <%= form.label :renewal_duration, "Renewal duration" %>
+                  <%= form.number_field :renewal_duration, class: "input" %>
+                </div>
+              </div>
+              <div class="column is-3">
+                <div class="field bottom-align">
+                  <%= form.label :renewal_duration_units, "Renewal duration units" %>
+                  <%= form.select :renewal_duration_units, TimePeriod.to_a, {:include_blank => true}, class: "input " %>
+                </div>
+              </div>
+              <div class="column is-3">
+                <div class="field bottom-align">
+                  <%= form.label :renewal_count, "Remaining renewals" %>
+                  <%= form.number_field :renewal_count, class: "input" %>
+                </div>
+              </div>
+              <div class="column is-3">
+                <div class="field bottom-align">
+                  <%= form.label :max_renewal_count, "Maximum renewals" %>
+                  <%= form.number_field :max_renewal_count, class: "input" %>
+                </div>
+              </div>
+            </div>
+
+            <div class="columns">
+              <div class="column is-3">
+                <div class="field bottom-align">
+                  <%= form.label :extension_duration, "Extension duration" %>
+                  <%= form.number_field :extension_duration, class: "input" %>
+                </div>
+              </div>
+              <div class="column is-3">
+                <div class="field bottom-align">
+                  <%= form.label :extension_duration_units, "Extension duration units" %>
+                  <%= form.select :extension_duration_units, TimePeriod.to_a, {:include_blank => true}, class: "input " %>
+                </div>
+              </div>
+              <div class="column is-3">
+                <div class="field bottom-align">
+                  <%= form.label :extension_count, "Remaining extensions" %>
+                  <%= form.number_field :extension_count, class: "input" %>
+                </div>
+              </div>
+              <div class="column is-3">
+                <div class="field bottom-align">
+                  <%= form.label :max_extension_count, "Maximum extensions" %>
+                  <%= form.number_field :max_extension_count, class: "input" %>
+                </div>
               </div>
             </div>
           </div>
@@ -209,6 +313,7 @@
               <% end %>
             </tbody>
           </table>
+        
         </div>
       </div>
     </div>
@@ -227,4 +332,5 @@
     </footer>
     <% end %>
   </div>
+  <script type="text/javascript">updateForm()</script>
 </div>

--- a/app/views/contracts/index.html.erb
+++ b/app/views/contracts/index.html.erb
@@ -59,7 +59,13 @@
               <td><%= contract.number %></td>
               <td><%= contract.point_of_contact.first_name %> <%= contract.point_of_contact.last_name %></td>
               <td><%= contract.starts_at.strftime("%B %d, %Y") %></td>
-              <td><%= contract.ends_at.strftime("%B %d, %Y") %></td>
+              <td>
+                <% if contract.ends_at.present? && contract.end_trigger == "limited_term" %>
+                  <%= contract.ends_at.strftime("%B %d, %Y") %>
+                <% else %>
+                  N/A
+                <% end %>
+              </td>
               <td><%= number_to_currency(contract.amount_dollar) %> per <%= contract.amount_duration %></td>
               <td><%= contract_status_icon(contract) %></td>
             </tr>

--- a/db/migrate/20231106210807_add_renews_expires_to_contracts.rb
+++ b/db/migrate/20231106210807_add_renews_expires_to_contracts.rb
@@ -1,0 +1,12 @@
+class AddRenewsExpiresToContracts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :contracts, :ends_at_final, :date
+    add_column :contracts, :max_renewal_count, :integer
+    add_column :contracts, :renewal_duration, :integer
+    add_column :contracts, :renewal_duration_units, :string
+    add_column :contracts, :extension_count, :integer
+    add_column :contracts, :max_extension_count, :integer
+    add_column :contracts, :extension_duration, :integer
+    add_column :contracts, :extension_duration_units, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_07_223210) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_06_210807) do
   create_table "bvcog_configs", force: :cascade do |t|
     t.text "contracts_path", null: false
     t.text "reports_path", null: false
@@ -58,6 +58,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_07_223210) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "renewal_count", default: 1
+    t.date "ends_at_final"
+    t.integer "max_renewal_count"
+    t.integer "renewal_duration"
+    t.string "renewal_duration_units"
+    t.integer "extension_count"
+    t.integer "max_extension_count"
+    t.integer "extension_duration"
+    t.string "extension_duration_units"
     t.index ["entity_id"], name: "index_contracts_on_entity_id"
     t.index ["point_of_contact_id"], name: "index_contracts_on_point_of_contact_id"
     t.index ["program_id"], name: "index_contracts_on_program_id"


### PR DESCRIPTION
Initial logic for adding contract duration change logic per customer requirements. 

Changes...
- Limited Term Contracts now have a maximum number of renews, a current number of renews, and a renew period expressed as a tuple of (number, unit of time) for example (6, months)
- Limited Term Contracts now have a maximum number of extensions, a current number of extensions, and a extension period expressed as a tuple of (number, unit of time) for example (6, months)
- Limited Term Contracts now have a final end date and an "end date of initial term"
- Continuous and Upon Completion contracts no longer have renews
- Continuous and Upon Completion contracts no longer have end dates
- Contract creation page dynamically changes to include/exclude fields that are relevant based on the end-trigger/contract length
- Contracts index page now only shows end-dates in the sortable column for limited term contracts
- View Contract page now only shows end dates, extensions, and renews for limited term contracts
- Contracts DB table now contains extra entries for ends_at_final, max_renewal_count, renewal_duration, renewal_duration_units, extension_count, max_extension_count, extension_duration, & extension_duration_units

No tests have been added, pending verification of logic from customer.